### PR TITLE
New Error Handling Pattern

### DIFF
--- a/src/drivers/express/ExpressResponder.ts
+++ b/src/drivers/express/ExpressResponder.ts
@@ -1,13 +1,13 @@
 import { Responder } from '../../interfaces/interfaces';
 import { Response } from 'express';
-import { ClientError } from '../../types';
+import { ClientError, GENERIC_REASON } from '../../types';
 export class ExpressResponder implements Responder {
   constructor(private res: Response) {}
   sendOperationSuccess(): void {
     this.res.sendStatus(200);
   }
   sendOperationError(error: ClientError): void {
-    this.res.status(error.status).send(error);
+    this.res.status(error && error.error && error.error.reason ? error.error.reason : GENERIC_REASON.UNEXPECTED_ERROR).send(error);
   }
   sendObject(object: any): void {
     this.res.status(200).send(object);

--- a/src/drivers/express/ExpressResponder.ts
+++ b/src/drivers/express/ExpressResponder.ts
@@ -1,15 +1,13 @@
 import { Responder } from '../../interfaces/interfaces';
 import { Response } from 'express';
+import { ClientError } from '../../types';
 export class ExpressResponder implements Responder {
   constructor(private res: Response) {}
   sendOperationSuccess(): void {
     this.res.sendStatus(200);
   }
-  sendOperationError(
-    error: string = 'Server error encounter.',
-    status: number = 400,
-  ): void {
-    this.res.status(status).send(error);
+  sendOperationError(error: ClientError): void {
+    this.res.status(error.status).send(error.message);
   }
   sendObject(object: any): void {
     this.res.status(200).send(object);

--- a/src/drivers/express/ExpressResponder.ts
+++ b/src/drivers/express/ExpressResponder.ts
@@ -7,7 +7,7 @@ export class ExpressResponder implements Responder {
     this.res.sendStatus(200);
   }
   sendOperationError(error: ClientError): void {
-    this.res.status(error.status).send(error.message);
+    this.res.status(error.status).send(error);
   }
   sendObject(object: any): void {
     this.res.status(200).send(object);

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -31,6 +31,7 @@ export class ExpressRouteDriver {
     });
 
     router.get('/outcomes', async (req, res) => {
+      const responder = this.getResponder(res);
       try {
         let filter: OutcomeFilter = {
           text: req.query.text ? req.query.text : '',
@@ -40,19 +41,20 @@ export class ExpressRouteDriver {
         };
         let page = req.query.page ? +req.query.page : undefined;
         let limit = req.query.limit ? +req.query.limit : undefined;
-        await SuggestionInteractor.searchOutcomes(
+        const outcomes = await SuggestionInteractor.searchOutcomes(
           this.dataStore,
-          this.getResponder(res),
           filter,
           page,
           limit,
         );
+        responder.sendObject(outcomes);
       } catch (e) {
-        console.log(e);
+        responder.sendOperationError(e);
       }
     });
 
     router.get('/outcomes/suggest', async (req, res) => {
+      const responder = this.getResponder(res);
       try {
         const mode: suggestMode = 'text';
         const scoreThreshold: number = process.env.SUGGESTION_THRESHOLD
@@ -66,17 +68,17 @@ export class ExpressRouteDriver {
         };
         let page = req.query.page ? +req.query.page : undefined;
         let limit = req.query.limit ? +req.query.limit : undefined;
-        await SuggestionInteractor.suggestOutcomes(
+        const outcomes = await SuggestionInteractor.suggestOutcomes(
           this.dataStore,
-          this.getResponder(res),
           filter,
           mode,
           scoreThreshold,
           limit,
           page,
         );
+        responder.sendObject(outcomes);
       } catch (e) {
-        console.log(e);
+        responder.sendOperationError(e);
       }
     });
 

--- a/src/interactors/SuggestionInteractor.ts
+++ b/src/interactors/SuggestionInteractor.ts
@@ -45,7 +45,6 @@ export class SuggestionInteractor {
       const clientErr: ClientError = {
         message: `Could not suggest outcomes.`,
         error: e,
-        status: e.reason ? e.reason : GENERIC_REASON.UNEXPECTED_ERROR,
       };
       return Promise.reject(clientErr);
     }
@@ -76,7 +75,6 @@ export class SuggestionInteractor {
       const clientErr: ClientError = {
         message: `Could not search outcomes.`,
         error: e,
-        status: e.reason ? e.reason : GENERIC_REASON.UNEXPECTED_ERROR,
       };
       return Promise.reject(clientErr);
     }
@@ -98,7 +96,6 @@ export class SuggestionInteractor {
       const clientErr: ClientError = {
         message: `Could not fetch sources.`,
         error: e,
-        status: e.reason ? e.reason : GENERIC_REASON.UNEXPECTED_ERROR,
       };
       return Promise.reject(clientErr);
     }

--- a/src/interfaces/Responder.ts
+++ b/src/interfaces/Responder.ts
@@ -1,7 +1,8 @@
 import { Response } from 'express';
+import { ClientError } from '../types';
 export interface Responder {
   sendOperationSuccess(): void;
-  sendOperationError(error?: string, status?: number): void;
+  sendOperationError(error: ClientError): void;
   sendObject(object: any): void;
 
   writeStream(): Response;

--- a/src/types/ClientError.ts
+++ b/src/types/ClientError.ts
@@ -1,0 +1,7 @@
+import { Reason } from './reason';
+
+export interface ClientError {
+  error: any;
+  message: string;
+  status: Reason;
+}

--- a/src/types/ClientError.ts
+++ b/src/types/ClientError.ts
@@ -1,7 +1,4 @@
-import { Reason } from './reason';
-
 export interface ClientError {
   error: any;
   message: string;
-  status: Reason;
 }

--- a/src/types/DriverError.ts
+++ b/src/types/DriverError.ts
@@ -1,0 +1,12 @@
+import { DriverReason } from './reason';
+
+export class DriverError extends Error {
+  reason: DriverReason;
+
+  constructor(message: string, reason: DriverReason) {
+    super(message);
+    this.reason = reason;
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, DriverError.prototype);
+  }
+}

--- a/src/types/ServiceError.ts
+++ b/src/types/ServiceError.ts
@@ -1,0 +1,11 @@
+import { ServiceReason } from './reason';
+
+export class ServiceError extends Error {
+  reason: number;
+  constructor(message: string, reason: ServiceReason) {
+    super(message);
+    this.reason = reason;
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, ServiceError.prototype);
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,27 @@
+import {
+  REASON,
+  Reason,
+  GENERIC_REASON,
+  GenericReason,
+  DRIVER_REASON,
+  DriverReason,
+  SERVICE_REASON,
+  ServiceReason,
+} from './reason';
+import { DriverError } from './DriverError';
+import { ServiceError } from './ServiceError';
+import { ClientError } from './ClientError';
+
+export {
+  REASON,
+  Reason,
+  GENERIC_REASON,
+  GenericReason,
+  DRIVER_REASON,
+  DriverReason,
+  SERVICE_REASON,
+  ServiceReason,
+  DriverError,
+  ServiceError,
+  ClientError,
+};

--- a/src/types/reason.ts
+++ b/src/types/reason.ts
@@ -1,0 +1,21 @@
+export enum REASON {
+  METHOD_NOT_IMPLEMENTED = 501,
+  BAD_REQUEST = 400,
+}
+export enum GENERIC_REASON {
+  UNEXPECTED_ERROR = 500,
+}
+
+export type GenericReason = GENERIC_REASON;
+
+export enum DRIVER_REASON {
+  RESOURCE_NOT_FOUND = 404,
+}
+export type DriverReason = GenericReason | DRIVER_REASON;
+
+export enum SERVICE_REASON {
+  NOT_AUTHORIZED = 403,
+}
+export type ServiceReason = GenericReason | SERVICE_REASON;
+
+export type Reason = REASON | GenericReason | DriverReason | ServiceReason;

--- a/src/types/reason.ts
+++ b/src/types/reason.ts
@@ -1,6 +1,6 @@
 export enum REASON {
-  METHOD_NOT_IMPLEMENTED = 501,
   BAD_REQUEST = 400,
+  METHOD_NOT_IMPLEMENTED = 501,
 }
 export enum GENERIC_REASON {
   UNEXPECTED_ERROR = 500,
@@ -11,11 +11,11 @@ export type GenericReason = GENERIC_REASON;
 export enum DRIVER_REASON {
   RESOURCE_NOT_FOUND = 404,
 }
-export type DriverReason = GenericReason | DRIVER_REASON;
+export type DriverReason = GenericReason | DRIVER_REASON | REASON;
 
 export enum SERVICE_REASON {
   NOT_AUTHORIZED = 403,
 }
-export type ServiceReason = GenericReason | SERVICE_REASON;
+export type ServiceReason = GenericReason | SERVICE_REASON | REASON;
 
-export type Reason = REASON | GenericReason | DriverReason | ServiceReason;
+export type Reason = GenericReason | DriverReason | ServiceReason;

--- a/src/utils/handlePromise.ts
+++ b/src/utils/handlePromise.ts
@@ -1,0 +1,30 @@
+/**
+ *  Handles Promise by returning data if successful.
+ * If an error occurs it will throw the Error object provided and inject message.
+ * If no Error object is provided, the error is returned
+ *
+ * @export
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {Error} [error]
+ * @returns {Promise<T>}
+ */
+export function handlePromise<T>(
+  promise: Promise<T>,
+  error?: Error,
+): Promise<T> {
+  return promise.then<T>((data: T) => data).catch<T>(e => {
+    if (error) {
+      error.message =
+        error.message &&
+        error.message !== 'null' &&
+        error.message !== 'undefined'
+          ? error.message
+          : e instanceof Error
+            ? e.message
+            : e;
+      throw error;
+    }
+    return e;
+  });
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+import { handlePromise } from './handlePromise';
+
+export { handlePromise };


### PR DESCRIPTION
### **Motivation**
Services currently use `try catch` blocks to handle all errors that may occur during asynchronous processes. At the driver level, any errors that are thrown are caught and returned as rejected Promises instead of thrown. There is also no status code associated with errors that occur. This makes it difficult to track down issues in services as well as send the appropriate status code to the client and message.

### **Proposed Solution**
To remedy this problem, I suggest that we remove rejected Promises from the driver level and instead throw the appropriate `Error` object. We should also use `console.error` at the interactor level to log out stack traces from thrown errors. Lastly we should return a specialized error object to the client that contains information needed to diagnose the issue and display a user facing message. 

To facilitate these changes, I have created four `Reason` types, two new `Error` objects, `DriverError` and `ServiceError`, an interface `ClientError`, and a `handlePromise` function. These components work together to create consistency in the way errors are handled and to make errors more descriptive and meaningful.

### **Reason Enums & Types**
The reason enums are used to map the cause of an error to an appropriate response status code. `Reason` types are used to extend the various reason enums.
#### Enums
##### `REASON`- Can be used in any `Error` Object
- `BAD_REQUEST`: maps to status code `400`. To be used in the case where a failure occurs due to request parameters being malformed.
- `METHOD_NOT_IMPLEMENTED`: maps to status code `501`. To be used in the case where a failure occurs due to a method not being implemented.
##### `GENERIC_REASON`- Can be used in any `Error` Object
- `UNEXPECTED_ERROR`: maps to status code `500`. To be used in the case where a failure occurs due to an unknown issue.
##### `DRIVER_REASON` - Can be used in `DriverError` object 
- `RESOURCE_NOT_FOUND`: maps to status code `404`. To be used in the case where a failure occurs due to an unresolvable resource .
##### `SERVICE_REASON` - Can be used in `ServiceError` object
- `NOT_AUTHORIZED`: maps to status code `403`. To be used in the case where a failure occurs because of user's access privileges.
#### Types
- `GenericReason`: is equal to the `GENERIC_REASON` enum.
- `DriverReason`: is the union type between the `GenericReason` type, `DRIVER_REASON` enum, and the `REASON` enum.
- `ServiceReason`: is the union type between the `GenericReason` type, `SERVICE_REASON` enum, and the `REASON` enum.
- `Reason`: is the union type of the `REASON` enum, `GenericReason` type, `DriverReason`, and `ServiceReason`.
### **Error Objects**
- `DriverError`: is to be thrown at the driver level and provided a `message:string` and `reason:DriverReason`
- `ServiceError`: is to be thrown at the service level (any level external to driver level as of now) and provided a `message:string` and `reason:ServiceReason`
### **ClientError**
This interface defines the structure of the object to be sent to the client when an error occurs.
### **handlePromise**
This function wraps Promises,  behaves like a try catch block, and can be passed in an `Error` object. If the Promise is successfully resolved the data is returned as expected. If an error occurs it catches the error and applies custom error handling logic. If an `Error` object is provided, the catch block will inject the message from the caught error if no custom message is provided and throw the `Error` object.

This function allows error to be handled at a more granular level than a `try catch` block, which can encourage more descriptive error messages and usage of appropriate status codes.