### PR TITLE
Remove lingering "this" pointer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-suggestion-service",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-suggestion-service",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Microservice that suggests user outcomes and standard outcomes",
   "scripts": {
     "start": "npm run gulp-tsc",

--- a/src/Search/ExpressRouteAdapter.ts
+++ b/src/Search/ExpressRouteAdapter.ts
@@ -35,7 +35,7 @@ export function buildRouter() {
     });
     router.get('/outcomes/sources', async (req, res) => {
         try {
-            const sources = await fetchSources(this.dataStore);
+            const sources = await fetchSources(dataStore);
             // TODO: Should this be JSON?
             res.status(200).send(sources);
         } catch (e) {
@@ -45,7 +45,7 @@ export function buildRouter() {
     });
     router.get('/outcomes/areas', async (req, res) => {
         try {
-            const areas = await fetchAreas(this.dataStore);
+            const areas = await fetchAreas(dataStore);
             res.json(areas);
         } catch (e) {
             res.status(500).send('Internal Server Error');


### PR DESCRIPTION
During the refactor, the interactor functions were moved from a static class to being directly exported from the module. Two calls to `this.dataStore` were not updated. This PR fixes those.