### PR TITLE
Remove integration test job requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,6 @@ workflows:
             branches:
               only: /master/
       - deploy-production:
-          requires:
-            - integration-test
           filters:
             branches:
               only: /master/


### PR DESCRIPTION
The integration test job was still required to deploy to production, even though it was removed. This requirement has now been removed so deployments should work again. 