### PR TITLE
Require Build for Deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ workflows:
               only: /master/
       - deploy-production:
           requires:
-            - integration-test
+            - build
           filters:
             branches:
               only: /master/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,8 @@ workflows:
             branches:
               only: /master/
       - deploy-production:
+          requires:
+            - integration-test
           filters:
             branches:
               only: /master/


### PR DESCRIPTION
Reverts Cyber4All/outcome-suggestion-service#55 and requires build before deployment.