### PR TITLE
Add missing host header to aws elastic search request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-suggestion-service",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-suggestion-service",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Microservice that suggests user outcomes and standard outcomes",
   "scripts": {
     "start": "npm run gulp-tsc",

--- a/src/Shared/ElasticSearchHelpers.ts
+++ b/src/Shared/ElasticSearchHelpers.ts
@@ -43,6 +43,9 @@ export function queryGuidelines(
       uri: GUIDELINE_URI,
       json: true,
       body: query,
+      headers: {
+        'Host': process.env.ELASTIC_SEARCH_HEADER,
+      },
     })
       .then((res: SearchResponse<Partial<StandardOutcome>>) =>
         resolve(toPaginatedGuidelines(res)),


### PR DESCRIPTION
According to AWS, our Elastic Search cluster has been recieving requests that contain an invalid host header.
<img width="1485" alt="Screen Shot 2019-05-20 at 7 22 05 PM" src="https://user-images.githubusercontent.com/32280549/58112549-c37a7d80-7bc1-11e9-90e3-6f27bc016f6f.png">

This PR sets the correct host header.

Documentation here: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-handling-errors.html