### PR TITLE
Increase default limit for Elastic Search results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-suggestion-service",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-suggestion-service",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Microservice that suggests user outcomes and standard outcomes",
   "scripts": {
     "start": "npm run gulp-tsc",

--- a/src/Search/ElasticSearchGateway.ts
+++ b/src/Search/ElasticSearchGateway.ts
@@ -62,7 +62,6 @@ export class ElasticSearchGateway implements Partial<OutcomeGateway> {
       [queryKey: string]: any,
     } = {};
     let paginator = { from: 0, size: 0 };
-    const defaultLimit = 20;
     let post_filter: {
       bool: {
         must: any[],
@@ -83,7 +82,6 @@ export class ElasticSearchGateway implements Partial<OutcomeGateway> {
     }
 
 
-    limit = limit || defaultLimit;
     paginator = buildPaginator({ limit, page });
 
     if (fieldQuery.source || fieldQuery.date) {

--- a/src/Shared/ElasticSearchHelpers.ts
+++ b/src/Shared/ElasticSearchHelpers.ts
@@ -12,6 +12,12 @@ import {
 const ELASTIC_SEARCH_URI = process.env.ELASTIC_SEARCH_URI;
 const GUIDELINE_URI = `${ELASTIC_SEARCH_URI}/enguidelines/_search`;
 
+/**
+ * Default limit is set to 350 to allow a decent sized result set to be returned if client has not specified a limit
+ * This number represents the total number of outcomes from the source with the most outcomes plus an added buffer range
+ */
+const DEFAULT_RESULT_SIZE = 350;
+
 export interface ElasticSearchQuery { [queryKey: string]: any; }
 
 export interface ElasticSearchPaginator {
@@ -114,7 +120,10 @@ function transformRequestError(e: RequestError, message?: string) {
 }
 
 /**
- * Builds pagination object
+ * Builds pagination object which includes the size (Maximum amount of results to return or limit) and from (What section of results to return or page) properties
+ * *** If no limit is defined, the default limit is used. ***
+ * *** from (page) + size (limit) can not be more than the index.max_result_window index setting which defaults to 10,000. ***
+ * *** https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-from-size.html ***
  *
  * @private
  * @param {number} limit [The maximum amount results to return]
@@ -123,7 +132,7 @@ function transformRequestError(e: RequestError, message?: string) {
  * @memberof ElasticSearchGateway
  */
 export function buildPaginator({
-  limit,
+  limit = DEFAULT_RESULT_SIZE,
   page,
 }: {
   limit: number;

--- a/src/Suggestion/ElasticSuggestionGateway.ts
+++ b/src/Suggestion/ElasticSuggestionGateway.ts
@@ -45,9 +45,7 @@ export class ElasticSuggestionGateway implements SuggestionGateway {
         analyzer: this.analyzers.stop_words,
       },
     };
-    if (limit > 0) {
-      paginator = buildPaginator({ limit, page });
-    }
+    paginator = buildPaginator({ limit, page });
     return { query, ...paginator };
   }
 }


### PR DESCRIPTION
This PR increases the default limit for Elastic Search results when clients have not specified a limit.