### PR TITLE
Ignore build-and-test workflow when merging into master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,10 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore: /master/
 
   build-test-and-deploy-production:
     jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-suggestion-service",
-  "version": "2.1.2",
+  "version": "2.1.3-3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outcome-suggestion-service",
-  "version": "2.1.2",
+  "version": "2.1.3-3",
   "description": "Microservice that suggests user outcomes and standard outcomes",
   "scripts": {
     "start": "npm run gulp-tsc",


### PR DESCRIPTION
***Purpose***
This PR is in response to story https://app.clubhouse.io/clarkcan/story/842/only-run-non-deployment-pipeline-on-branches-that-aren-t-master

***Implementation***
Uses the ignore option for the master branch

Circle CI branch filtering docs: https://circleci.com/docs/2.0/configuration-reference/#filters-1